### PR TITLE
Do not create spark namespace in helm command

### DIFF
--- a/apps/templates/fink-broker.yaml
+++ b/apps/templates/fink-broker.yaml
@@ -29,7 +29,3 @@ spec:
   destination:
     server: {{ .Values.spec.destination.server }}
     namespace: {{ .Values.spec.sparkNamespace }}
-  syncPolicy:
-    syncOptions:
-    # - Replace=true
-    - CreateNamespace=true


### PR DESCRIPTION
spark namespace is create in fink-broker chat with "monitoring" label